### PR TITLE
[#1] Docker로 배포

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,10 +20,39 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Make application-secret.yml
+        run: |
+          touch ./src/main/resources/application-secret.yml
+          echo "${{ secrets.APPLICATION }}" > ./src/main/resources/application-secret.yml
+          cat ./src/main/resources/application-secret.yml
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Create application-secret.yml file and Deploy to NCP (Server 1)
+      - name: Build with Gradle (without Test)
+        run: ./gradlew clean build -x test --stacktrace
+
+        # 도커 로그인
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+        # 도커 이미지 빌드 및 푸쉬
+      - name: Build Docker image & Push it to Docker Hub
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/flea-market:latest
+
+        # 배포 및 백그라운드 실행
+      - name: Deploy to NCP (WAS 01)
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.NCP_SERVER_SSH_PUBLIC_IP }}
@@ -31,15 +60,14 @@ jobs:
           username: ${{ secrets.NCP_SERVER_USER }}
           password: ${{ secrets.NCP_SERVER_PASSWORD }}
           script: |
-            cd /root/app/flea-market/gift-card-flea-market
-            touch ./src/main/resources/application-secret.yml
-            echo "${{ secrets.APPLICATION }}" > ./src/main/resources/application-secret.yml
-            
             cd /root/app/flea-market
-            chmod +x ./deploy.sh
-            ./deploy.sh
+            sudo docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_TOKEN }}
+            sudo docker rm -f $(sudo docker ps -qa)
+            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/flea-market:latest
+            sudo docker-compose up -d
+            sudo docker image prune -f
 
-      - name: Create application-secret.yml file and Deploy to NCP (Server 2)
+      - name: Deploy to NCP (WAS 02)
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.NCP_SERVER_SSH_PUBLIC_IP }}
@@ -47,10 +75,9 @@ jobs:
           username: ${{ secrets.NCP_SERVER_USER }}
           password: ${{ secrets.NCP_SERVER_PASSWORD }}
           script: |
-            cd /root/app/flea-market/gift-card-flea-market
-            touch ./src/main/resources/application-secret.yml
-            echo "${{ secrets.APPLICATION }}" > ./src/main/resources/application-secret.yml
-
             cd /root/app/flea-market
-            chmod +x ./deploy.sh
-            ./deploy.sh
+            sudo docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_TOKEN }}
+            sudo docker rm -f $(sudo docker ps -qa)
+            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/fleamarket:latest
+            sudo docker-compose up -d
+            sudo docker image prune -f

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Create application-secret.yml file
-        run: |
-          touch ./src/main/resources/application-secret.yml
-          echo "${{ secrets.APPLICATION }}" > ./src/main/resources/application-secret.yml
-          cat ./src/main/resources/application-secret.yml
-
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
+
+      - name: Make application-secret.yml
+        run: |
+          touch ./src/main/resources/application-secret.yml
+          echo "${{ secrets.APPLICATION }}" > ./src/main/resources/application-secret.yml
+          cat ./src/main/resources/application-secret.yml
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:17-jdk-alpine
+ARG JAR_FILE=*-SNAPSHOT.jar
+COPY build/libs/${JAR_FILE} app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  app:
+    container_name: app
+    image: flea-market:latest
+    expose:
+      - "8080"
+    ports:
+      - "8080:8080"


### PR DESCRIPTION
기존 Github Actions의 CD workflow는 스크립트로 모든 배포 작업이 이루어지므로 호스트에 매우 의존적인 형태.
1. WAS 서버 원격접속
2. deploy.sh 실행 (git pull -> 프로젝트 빌드 -> 실행 중인 자바 프로세스 확인 후, 있으면 kill -> 애플리케이션 실행)


**Docker 적용 -> 호스트 시스템에 독립적**
1. Docker Hub 로그인
2. Docker image 빌드 및 푸쉬
4. WAS 서버 원격접속
5. Docker Hub 로그인 및 이미지 가져오기 
6. 컨테이너 백그라운드 실행